### PR TITLE
Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ FakesAssemblies/
 *.exe
 *.out
 *.app
+
+# Outdir
+/out

--- a/ApplyPatch/Main.cpp
+++ b/ApplyPatch/Main.cpp
@@ -2,7 +2,7 @@
 //
 
 #include "stdafx.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include "FileUtils.h"
 #include "LogSystem.h"
 #include "ApplyPatch.h"
@@ -58,4 +58,3 @@ int main(int argc, char* argv[])
 	else
 		exit(EXIT_FAILURE);
 }
-

--- a/CreatePatch/stdafx.h
+++ b/CreatePatch/stdafx.h
@@ -9,8 +9,8 @@
 	#include <malloc.h>
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
-#include <assert.h>
+#include <cassert>
 #include <vector>
 #include <algorithm>

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 CC=g++
 AR=ar
-CXXFLAGS=-c -Wall -std=c++14
+CXXFLAGS=-c -Wall -Wextra -std=c++14 -Wno-unused-parameter -Wno-unused-variable
 CPPFLAGS=-I$(ZPATCHERLIBDIR) -Ilibs/LzmaLib/source
-LDFLAGS=
+LDFLAGS= -L$(LZMADIR)/out
 ARFLAGS=-rvs
 
-LZMALIB=./libs/LzmaLib/source/out/liblzma.a
+LZMADIR=./libs/LzmaLib/source
+LZMALIB=$(LZMADIR)/out/liblzma.a
+
+LIBS=-llzma -lpthread
 
 # ZPatcherLib files
 ZPATCHERLIBDIR=ZPatcherLib
@@ -25,17 +28,23 @@ APPLYPATCHOBJECTS=$(addprefix obj/$(APPLYPATCHDIR)/, $(notdir $(APPLYPATCHSOURCE
 # A directory creation utility
 create_output_dir=@mkdir -p $(@D)
 
-all: out/ZPatcherLib.a out/CreatePatch out/ApplyPatch
+.PHONY: all lzma clean
+
+all: lzma out/ZPatcherLib.a out/CreatePatch out/ApplyPatch
 	@echo all done.
 
+lzma:
+	@ $(MAKE) -C $(LZMADIR)
+
 clean:
-	rm -rf obj/
-	rm -rf out/
+	@ rm -rf obj/
+	@ rm -rf out/
+	@ $(MAKE) -C $(LZMADIR) clean
 
 # CreatePatch executable
 out/CreatePatch: $(CREATEPATCHOBJECTS) out/ZPatcherLib.a
 	$(create_output_dir)
-	$(CC) $(LDFLAGS) $(LZMALIB)	$^ -o $@
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 $(CREATEPATCHOBJECTS): obj/$(CREATEPATCHDIR)/%.o: $(CREATEPATCHDIR)/%.cpp
 	$(create_output_dir)
@@ -44,7 +53,7 @@ $(CREATEPATCHOBJECTS): obj/$(CREATEPATCHDIR)/%.o: $(CREATEPATCHDIR)/%.cpp
 # ApplyPatch executable
 out/ApplyPatch: $(APPLYPATCHOBJECTS) out/ZPatcherLib.a
 	$(create_output_dir)
-	$(CC) $(LDFLAGS) $(LZMALIB) $^ -o $@
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 $(APPLYPATCHOBJECTS): obj/$(APPLYPATCHDIR)/%.o: $(APPLYPATCHDIR)/%.cpp
 	$(create_output_dir)

--- a/ZPatcherLib/ApplyPatch.cpp
+++ b/ZPatcherLib/ApplyPatch.cpp
@@ -12,10 +12,10 @@
 
 
 #include "stdafx.h"
-#include <stdio.h>
+#include <cstdio>
 #include <string>
-#include <errno.h>
-#include <stdint.h>
+#include <cerrno>
+#include <cstdint>
 #include "ApplyPatch.h"
 #include "Lzma2Decoder.h"
 #include "LogSystem.h"
@@ -188,7 +188,7 @@ bool ZPatcher::RestoreBackup(std::vector<std::string>& backupFileList, std::vect
 		std::string fullBackupFileName = baseDirectory + "/backup-" + previousVersionNumber + "/" + *itr;
 
 		CreateDirectoryTree(fullFilename); // Lazy++;
-		result = result && CopyOneFile(fullBackupFileName, fullFilename);		
+		result = result && CopyOneFile(fullBackupFileName, fullFilename);
 	}
 
 	for (std::vector<std::string>::iterator itr = addedFileList.begin(); itr < addedFileList.end(); ++itr)

--- a/ZPatcherLib/ApplyPatch.h
+++ b/ZPatcherLib/ApplyPatch.h
@@ -13,7 +13,7 @@
 #ifndef _APPLYPATCH_H_
 #define _APPLYPATCH_H_
 
-#include <string.h>
+#include <cstring>
 #include <vector>
 
 namespace ZPatcher

--- a/ZPatcherLib/CreatePatch.cpp
+++ b/ZPatcherLib/CreatePatch.cpp
@@ -16,8 +16,8 @@
 #include "FileUtils.h"
 #include "Lzma2Encoder.h"
 #include <algorithm>
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
 #include "LogSystem.h"
 
 void ZPatcher::PrintCreatePatchProgressBar(const float& Percentage, const uint64_t& leftAmount, const uint64_t& rightAmount)
@@ -239,4 +239,3 @@ bool ZPatcher::CreatePatchFile(std::string& patchFileName, std::string& newVersi
 
 	return result;
 }
-

--- a/ZPatcherLib/FileUtils.cpp
+++ b/ZPatcherLib/FileUtils.cpp
@@ -11,8 +11,8 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include <errno.h>
-#include <stdint.h>
+#include <cerrno>
+#include <cstdint>
 #include "FileUtils.h"
 #include "LogSystem.h"
 
@@ -88,7 +88,7 @@ bool ZPatcher::GetFilesInDirectory(std::vector<std::string>& fileList, const std
 
 bool ZPatcher::AreFilesIdentical(FILE* file1, FILE* file2, bool &result)
 {
-	
+
 	// Compare their size, first
 	fseek64(file1, 0, SEEK_END);
 	int64_t file1size = ftell64(file1);
@@ -354,4 +354,3 @@ bool ZPatcher::RemoveOneDirectory(const std::string& directory)
 
 	return true;
 }
-

--- a/ZPatcherLib/FileUtils.h
+++ b/ZPatcherLib/FileUtils.h
@@ -16,6 +16,7 @@
 
 #include <vector>
 #include <string>
+#include <cstring>
 
 namespace ZPatcher
 {

--- a/ZPatcherLib/LogSystem.cpp
+++ b/ZPatcherLib/LogSystem.cpp
@@ -11,12 +11,12 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include <string>
-#include <assert.h>
-#include <stdarg.h> 
-#include <chrono>
-#include <errno.h>
+#include <cstring>
+#include <cassert>
+#include <cstdarg>
+#include <cerrno>
 #include <ctime>
+#include <chrono>
 #include "LogSystem.h"
 #include "FileUtils.h"
 
@@ -69,7 +69,7 @@ std::string ZPatcher::BuildHumanTimeStamp()
 #endif
 
 	std::string humanTimestamp;
-	
+
 	char buffer[16];
 	sprintf(buffer, "%02d", timeinfo.tm_year + 1900);
 	humanTimestamp += buffer;
@@ -133,4 +133,3 @@ void ZPatcher::DestroyLogSystem()
 
 	g_LogSystem = nullptr;
 }
-

--- a/ZPatcherLib/LogSystem.h
+++ b/ZPatcherLib/LogSystem.h
@@ -13,7 +13,7 @@
 #ifndef _LOGSYSTEM_H_
 #define _LOGSYSTEM_H_
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 
 namespace ZPatcher

--- a/ZPatcherLib/Lzma2Decoder.cpp
+++ b/ZPatcherLib/Lzma2Decoder.cpp
@@ -11,9 +11,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include <stdint.h>
-#include <assert.h>
-#include <errno.h>
+#include <cstdint>
+#include <cassert>
+#include <cerrno>
 #include "Lzma2Dec.h"
 #include "Lzma2Decoder.h"
 #include "LzmaInterfaces.h"

--- a/ZPatcherLib/Lzma2Decoder.h
+++ b/ZPatcherLib/Lzma2Decoder.h
@@ -16,8 +16,9 @@
 
 #include "ZPatcherCurrentVersion.h"
 #include "Lzma2Dec.h"
-#include <stdio.h>
+#include <cstdio>
 #include <string>
+#include <cstring>
 
 namespace ZPatcher
 {

--- a/ZPatcherLib/Lzma2Encoder.cpp
+++ b/ZPatcherLib/Lzma2Encoder.cpp
@@ -15,9 +15,9 @@
 #include "Lzma2Encoder.h"
 #include "LzmaInterfaces.h"
 #include "LogSystem.h"
-#include <stdint.h>
-#include <errno.h>
-#include <assert.h>
+#include <cstdint>
+#include <cerrno>
+#include <cassert>
 
 #ifdef _WIN32
 	#define ftell64 _ftelli64

--- a/ZPatcherLib/Lzma2Encoder.h
+++ b/ZPatcherLib/Lzma2Encoder.h
@@ -17,8 +17,8 @@
 #include "ZPatcherCurrentVersion.h"
 #include "Lzma2Enc.h"
 #include "LzmaInterfaces.h"
-#include <stdio.h>
-#include <string>
+#include <cstdio>
+#include <cstring>
 
 namespace ZPatcher
 {

--- a/ZPatcherLib/LzmaInterfaces.h
+++ b/ZPatcherLib/LzmaInterfaces.h
@@ -12,11 +12,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 #ifndef _LZMAALLOCATORS_H_
-#define _LZMAALLOCATORS_H_ 
+#define _LZMAALLOCATORS_H_
 
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
 #include <string>
 
 #ifdef _WIN32

--- a/ZUpdater/DownloadFileWriter.cpp
+++ b/ZUpdater/DownloadFileWriter.cpp
@@ -11,8 +11,8 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 #include "DownloadFileWriter.h"
 #include "LogSystem.h"
 

--- a/ZUpdater/ZUpdater.cpp
+++ b/ZUpdater/ZUpdater.cpp
@@ -12,7 +12,7 @@
 #include "stdafx.h"
 #include <string>
 #include <vector>
-#include <limits.h>
+#include <climits>
 #include <io.h>
 
 #ifdef  _WIN32
@@ -484,7 +484,7 @@ namespace ZUpdater
 		// Read file and generate MD5 hash
 		md5_init(&state);
 
-		while (bytesRead = fread(readBuffer, 1, buffer_size, targetFile)) 
+		while (bytesRead = fread(readBuffer, 1, buffer_size, targetFile))
 			md5_append(&state, (const md5_byte_t*)readBuffer, static_cast<int>(bytesRead));
 
 		fclose(targetFile); // Close the file. It won't be needed anymore.
@@ -525,7 +525,7 @@ namespace ZUpdater
 
 		return true;
 	}
-	
+
 	//////////////////////////////////////////////////////////////////////////
 
 	bool SimpleDownloadFile(const std::string& URL, const std::string& targetPath)
@@ -661,4 +661,3 @@ namespace ZUpdater
 #endif _WIN32
 
 }
-

--- a/libs/LzmaLib/source/Makefile
+++ b/libs/LzmaLib/source/Makefile
@@ -11,12 +11,14 @@ LZMAOBJECTS=$(addprefix obj/,$(notdir $(LZMASOURCES:.c=.o)))
 # A directory creation utility
 create_output_dir=@mkdir -p $(@D)
 
+.PHONY: all clean
+
 all: out/liblzma.a
 	@echo all done.
 
 clean:
-	rm -rf obj/
-	rm -rf out/
+	@ rm -rf obj/
+	@ rm -rf out/
 
 out/liblzma.a: $(LZMAOBJECTS)
 	$(create_output_dir)


### PR DESCRIPTION
`<string.h>` is required for `strerror`, etc.

Also, in GCC / G++, undefined symbols are generally looked up in files after them on the command line.  That's why the -lwhatevers are usually last.
