### PR TITLE
Multiple Fixes to succesfully compile on Ubuntu, Gentoo and Mac OS (Big Sur)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ VisualCreatePatch: libs out/VisualCreatePatch
 
 ZLauncher: libs out/ZLauncher
 	@ cp -R ./ZLauncher/ZLauncherRes ./out/ZLauncherRes/
+	@ cp -n ./ZLauncher/ZLauncher.xml ./out/
 
 ZUpdater: libs out/ZUpdater
 

--- a/VisualCreatePatch/CreatePatchThread.cpp
+++ b/VisualCreatePatch/CreatePatchThread.cpp
@@ -12,6 +12,7 @@
 
 #include "stdafx.h"
 #include "wx/thread.h"
+#include "wx/msgdlg.h"
 #include "CreatePatchFrame.h"
 #include "CreatePatchThread.h"
 #include "LogSystem.h"

--- a/ZLauncher/ZLauncher.cpp
+++ b/ZLauncher/ZLauncher.cpp
@@ -34,6 +34,11 @@ bool ZLancher::OnInit()
 
 	wxInitAllImageHandlers();
 
+	// Initialize Config colors now wx is set up
+	m_Config.ApplicationBackground = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+	m_Config.ProgressBarTextBackground = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+	m_Config.ProgressBarTextForeground = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+
 	// The configuration XML file is the same as the executable. On Windows, it replaces the .exe extension
 	wxString ConfigPath = wxStandardPaths::Get().GetExecutablePath();
 

--- a/ZLauncher/ZLauncher.h
+++ b/ZLauncher/ZLauncher.h
@@ -23,9 +23,9 @@ struct ZLauncherConfig
 	std::string TargetDirectory;
 	std::string LaunchExecutable;
 	std::string BackgroundImage;
-	wxColour ApplicationBackground		{ wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW) };
-	wxColour ProgressBarTextBackground	{ wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW) };
-	wxColour ProgressBarTextForeground	{ wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT) };
+	wxColour ApplicationBackground;
+	wxColour ProgressBarTextBackground;
+	wxColour ProgressBarTextForeground;
 };
 
 class ZLancher : public wxApp

--- a/libs/LzmaLib/source/7zTypes.h
+++ b/libs/LzmaLib/source/7zTypes.h
@@ -9,16 +9,20 @@
 #else
 	// Undefined types/definitions that GCC needs to compile on modern 
 	// MacOS/linux, there is probably a better way of detecting this.
-	#ifndef LPVOID 
-		#define LPVOID void*
-		#define HRESULT long
-		#define BOOL _Bool
-		#define LONG unsigned long
+	#include <stdbool.h>
+	#include <stdint.h>
 
-		#define S_OK 0
-		#define E_FAIL 1
-		#define TRUE True
-		#define FALSE False
+	typedef int32_t		LONG;
+	typedef uint32_t	ULONG;
+	typedef void*		LPVOID;
+	typedef int32_t		HRESULT;
+
+	#ifndef S_OK
+		#define S_OK	((HRESULT)0x00000000L)
+	#endif
+
+	#ifndef E_FAIL
+		#define E_FAIL	((HRESULT)0x80000008L)
 	#endif
 #endif
 

--- a/libs/LzmaLib/source/7zTypes.h
+++ b/libs/LzmaLib/source/7zTypes.h
@@ -6,6 +6,20 @@
 
 #ifdef _WIN32
 /* #include <windows.h> */
+#else
+	// Undefined types/definitions that GCC needs to compile on modern 
+	// MacOS/linux, there is probably a better way of detecting this.
+	#ifndef LPVOID 
+		#define LPVOID void*
+		#define HRESULT long
+		#define BOOL _Bool
+		#define LONG unsigned long
+
+		#define S_OK 0
+		#define E_FAIL 1
+		#define TRUE True
+		#define FALSE False
+	#endif
 #endif
 
 #include <stddef.h>

--- a/libs/LzmaLib/source/7zTypes.h
+++ b/libs/LzmaLib/source/7zTypes.h
@@ -12,6 +12,7 @@
 	#include <stdbool.h>
 	#include <stdint.h>
 
+	typedef bool		BOOL;
 	typedef void*		LPVOID;
 	typedef int32_t		HRESULT;
 
@@ -21,6 +22,14 @@
 
 	#ifndef E_FAIL
 		#define E_FAIL	((HRESULT)0x80000008L)
+	#endif
+
+	#ifndef TRUE
+		#define TRUE	true
+	#endif
+
+	#ifndef FALSE
+		#define FALSE	false
 	#endif
 #endif
 

--- a/libs/LzmaLib/source/7zTypes.h
+++ b/libs/LzmaLib/source/7zTypes.h
@@ -12,8 +12,6 @@
 	#include <stdbool.h>
 	#include <stdint.h>
 
-	typedef int32_t		LONG;
-	typedef uint32_t	ULONG;
 	typedef void*		LPVOID;
 	typedef int32_t		HRESULT;
 

--- a/libs/LzmaLib/source/MtCoder.c
+++ b/libs/LzmaLib/source/MtCoder.c
@@ -355,7 +355,12 @@ static THREAD_FUNC_RET_TYPE THREAD_FUNC_CALL_TYPE ThreadFunc(void *pp)
       
       #ifndef MTCODER__USE_WRITE_THREAD
       {
+// InterlockedIncrement is defined in winnt.h, not available on POSIX systems
+#ifdef _WIN32
         unsigned numFinished = (unsigned)InterlockedIncrement(&mtc->numFinishedThreads);
+#else
+        unsigned numFinished = (unsigned)__sync_fetch_and_add(&mtc->numFinishedThreads, 1);
+#endif
         if (numFinished == mtc->numStartedThreads)
           if (Event_Set(&mtc->finishedEvent) != 0)
             return SZ_ERROR_THREAD;

--- a/libs/LzmaLib/source/MtCoder.c
+++ b/libs/LzmaLib/source/MtCoder.c
@@ -359,7 +359,7 @@ static THREAD_FUNC_RET_TYPE THREAD_FUNC_CALL_TYPE ThreadFunc(void *pp)
 #ifdef _WIN32
         unsigned numFinished = (unsigned)InterlockedIncrement(&mtc->numFinishedThreads);
 #else
-        unsigned numFinished = (unsigned)__sync_fetch_and_add(&mtc->numFinishedThreads, 1);
+        unsigned numFinished = (unsigned)__sync_add_and_fetch(&mtc->numFinishedThreads, 1);
 #endif
         if (numFinished == mtc->numStartedThreads)
           if (Event_Set(&mtc->finishedEvent) != 0)

--- a/libs/LzmaLib/source/MtCoder.h
+++ b/libs/LzmaLib/source/MtCoder.h
@@ -107,7 +107,7 @@ typedef struct _CMtCoder
     SRes writeRes;
     unsigned writeIndex;
     Byte ReadyBlocks[MTCODER__BLOCKS_MAX];
-    LONG numFinishedThreads;
+    Int32 numFinishedThreads;
   #endif
 
   unsigned numStartedThreadsLimit;

--- a/libs/rapidxml-1.13/rapidxml_print.hpp
+++ b/libs/rapidxml-1.13/rapidxml_print.hpp
@@ -101,6 +101,35 @@ namespace rapidxml
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
+
+	// Doing template definitions first, due to GCC name lookup changes, see:
+	// https://stackoverflow.com/questions/14113923/rapidxml-print-header-has-undefined-methods
+	template<class OutIt, class Ch>
+	inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_attributes(OutIt out, const xml_node<Ch> *node, int flags);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	template<class OutIt, class Ch>
+	inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
     
         // Print node
         template<class OutIt, class Ch>

--- a/libs/rapidxml-1.13/rapidxml_print.hpp
+++ b/libs/rapidxml-1.13/rapidxml_print.hpp
@@ -102,6 +102,9 @@ namespace rapidxml
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
 
+#ifdef __GNUC__
+	#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
+
 	// Doing template definitions first, due to GCC name lookup changes, see:
 	// https://stackoverflow.com/questions/14113923/rapidxml-print-header-has-undefined-methods
 	template<class OutIt, class Ch>
@@ -130,6 +133,10 @@ namespace rapidxml
 
 	template<class OutIt, class Ch>
 	inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+
+	#endif
+#endif
+
     
         // Print node
         template<class OutIt, class Ch>


### PR DESCRIPTION
Hiya,

I had to apply a few changes in order to compile on MacOS and Linux.

The changes in LzmaLib I am a bit uncomfortable with, in theory and through testing it works fine. However simply adding definitions for LPVOID and HRESULT feels like a cheap solution.

In libretro/neocd_libretro#16 they also suggest defining _7ZIP_ST to remove all code related to multithreading, removing the need for one windows-specific function to handle writes to one variable shared between threads. To avoid performance impact I opted to change the function for non-windows systems.

The other changes are tiny and self explanatory.

With these changes I can successfully compile on MacOS, Ubuntu and Gentoo. MacOS can also succesfully run ZLauncher, on the Linux systems ~~GTK is lacking a display connection possibly because I am using wayland instead of X11~~ is working now too. The other binaries ZUpdater, CreatePatch and ApplyPatch run perfectly in my limited testing.