### PR TITLE
Version 3.1

### DIFF
--- a/ApplyPatch/ApplyPatch.vcxproj
+++ b/ApplyPatch/ApplyPatch.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{9DD0592D-6DDC-4434-AF28-3A65E61FC97A}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ApplyPatch</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/ApplyPatch/Main.cpp
+++ b/ApplyPatch/Main.cpp
@@ -51,8 +51,6 @@ int main(int argc, char* argv[])
 	uint64_t version = 1;
 	bool success = ApplyPatchFile(patchFileName, targetDirectory, version); // TODO: Add a version file
 
-	DestroyLogSystem();
-
 	if (success)
 		exit(EXIT_SUCCESS);
 	else

--- a/CreatePatch/CreatePatch.vcxproj
+++ b/CreatePatch/CreatePatch.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{7B2587E3-02F9-4777-B70E-9016BEB741C2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CreatePatch</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/CreatePatch/Main.cpp
+++ b/CreatePatch/Main.cpp
@@ -47,11 +47,6 @@ int main(int argc, char* argv[])
 	std::string newDirectory = argv[2];
 	std::string outputFilename = argv[3];
 
-	// Make sure all directories are represented in the same format
-	NormalizeFileName(oldDirectory);
-	NormalizeFileName(newDirectory);
-	NormalizeFileName(outputFilename);
-
 	Log(LOG, "Output patch file: %s", outputFilename.c_str());
 	Log(LOG, "Old version directory: %s", oldDirectory.c_str());
 	Log(LOG, "New version directory: %s", newDirectory.c_str());

--- a/CreatePatch/Main.cpp
+++ b/CreatePatch/Main.cpp
@@ -63,8 +63,6 @@ int main(int argc, char* argv[])
 	if (patchFileList)
 		delete(patchFileList);
 
-	DestroyLogSystem();
-
 	exit(EXIT_SUCCESS);
 }
 

--- a/VisualCreatePatch/CreatePatchThread.cpp
+++ b/VisualCreatePatch/CreatePatchThread.cpp
@@ -58,7 +58,7 @@ wxThread::ExitCode CreatePatchThread::Entry()
 	using namespace ZPatcher;
 
 	// Check through execution if we should destroy the thread and exit
-	if (TestDestroy()) { ZPatcher::DestroyLogSystem(); return (wxThread::ExitCode)0; }
+	if (TestDestroy()) { return (wxThread::ExitCode)0; }
 
 	SetActiveLog("VisualCreatePatch");
 
@@ -71,7 +71,7 @@ wxThread::ExitCode CreatePatchThread::Entry()
 	std::string outputFilename = m_outputFilename.ToStdString();
 	NormalizeFileName(outputFilename);
 
-	if (TestDestroy()) { ZPatcher::DestroyLogSystem(); return (wxThread::ExitCode)0; }
+	if (TestDestroy()) { return (wxThread::ExitCode)0; }
 
 	if (m_importXml)
 	{
@@ -89,7 +89,7 @@ wxThread::ExitCode CreatePatchThread::Entry()
 		m_pPatchFileList = GetDifferences(oldDirectory, newDirectory, &CreatePatchFrame::UpdateComparisonDisplay);
 	}
 
-	if (TestDestroy()) { ZPatcher::DestroyLogSystem(); return (wxThread::ExitCode)0; }
+	if (TestDestroy()) { return (wxThread::ExitCode)0; }
 
 	if (m_exportXml)
 	{
@@ -104,6 +104,5 @@ wxThread::ExitCode CreatePatchThread::Entry()
 		CreatePatchFile(outputFilename, newDirectory, m_pPatchFileList, &CreatePatchFrame::UpdatePatchProcessedDisplay, { &CreatePatchFrame::OnLZMAProgress });
 	}
 
-	ZPatcher::DestroyLogSystem();
 	return (wxThread::ExitCode)0;     // success
 }

--- a/VisualCreatePatch/CreatePatchThread.cpp
+++ b/VisualCreatePatch/CreatePatchThread.cpp
@@ -96,7 +96,7 @@ wxThread::ExitCode CreatePatchThread::Entry()
 	{
 		// Then, create the patch file.
 		// This is ugly, since there is no way to check inside CreatePatch() if the thread was destroyed. Check if there's a better way to do this.
-		CreatePatchFileEx(outputFilename, newDirectory, m_pPatchFileList, &CreatePatchFrame::UpdatePatchProcessedDisplay, { &CreatePatchFrame::OnLZMAProgress });
+		CreatePatchFileEx(outputFilename, newDirectory, m_pPatchFileList, &CreatePatchFrame::UpdatePatchProcessedDisplay, reinterpret_cast<LZMA_ICompressProgress>(&CreatePatchFrame::OnLZMAProgress));
 	}
 
 	return (wxThread::ExitCode)0;     // success

--- a/VisualCreatePatch/CreatePatchThread.cpp
+++ b/VisualCreatePatch/CreatePatchThread.cpp
@@ -62,14 +62,9 @@ wxThread::ExitCode CreatePatchThread::Entry()
 
 	SetActiveLog("VisualCreatePatch");
 
-	std::string oldDirectory = m_oldDirectory.ToStdString();
-	NormalizeFileName(oldDirectory);
-
-	std::string newDirectory = m_newDirectory.ToStdString();
-	NormalizeFileName(newDirectory);
-
-	std::string outputFilename = m_outputFilename.ToStdString();
-	NormalizeFileName(outputFilename);
+	const std::string oldDirectory = m_oldDirectory.ToStdString();
+	const std::string newDirectory = m_newDirectory.ToStdString();
+	const std::string outputFilename = m_outputFilename.ToStdString();
 
 	if (TestDestroy()) { return (wxThread::ExitCode)0; }
 
@@ -86,7 +81,7 @@ wxThread::ExitCode CreatePatchThread::Entry()
 	else
 	{
 		// First, create the list of files to be added to the patch
-		m_pPatchFileList = GetDifferences(oldDirectory, newDirectory, &CreatePatchFrame::UpdateComparisonDisplay);
+		m_pPatchFileList = GetDifferencesEx(oldDirectory, newDirectory, &CreatePatchFrame::UpdateComparisonDisplay);
 	}
 
 	if (TestDestroy()) { return (wxThread::ExitCode)0; }
@@ -101,7 +96,7 @@ wxThread::ExitCode CreatePatchThread::Entry()
 	{
 		// Then, create the patch file.
 		// This is ugly, since there is no way to check inside CreatePatch() if the thread was destroyed. Check if there's a better way to do this.
-		CreatePatchFile(outputFilename, newDirectory, m_pPatchFileList, &CreatePatchFrame::UpdatePatchProcessedDisplay, { &CreatePatchFrame::OnLZMAProgress });
+		CreatePatchFileEx(outputFilename, newDirectory, m_pPatchFileList, &CreatePatchFrame::UpdatePatchProcessedDisplay, { &CreatePatchFrame::OnLZMAProgress });
 	}
 
 	return (wxThread::ExitCode)0;     // success

--- a/VisualCreatePatch/VisualCreatePatch.vcxproj
+++ b/VisualCreatePatch/VisualCreatePatch.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{33851E19-677D-4BCC-85ED-CBAFC6974B23}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VisualCreatePatch</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/ZLauncher/ZLauncher.vcxproj
+++ b/ZLauncher/ZLauncher.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{13285DCD-009D-453A-9CC6-A02F584568B3}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ZLauncher</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -104,7 +104,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_dll;$(SolutionDir)\libs\curl\build\Win32\VC14\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_dll;$(SolutionDir)\libs\curl\build\Win32\VC14.30\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurld.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
@@ -135,7 +135,7 @@ copy /y "$(SolutionDir)ZLauncher\ZLauncherRes" "$(OutDir)ZLauncherRes\" 1&gt;NUL
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14.30\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurld.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
@@ -168,7 +168,7 @@ copy /y "$(SolutionDir)ZLauncher\ZLauncherRes" "$(OutDir)ZLauncherRes\" 1&gt;NUL
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_dll;$(SolutionDir)\libs\curl\build\Win32\VC14\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_dll;$(SolutionDir)\libs\curl\build\Win32\VC14.30\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
@@ -201,7 +201,7 @@ copy /y "$(SolutionDir)ZLauncher\ZLauncherRes" "$(OutDir)ZLauncherRes\" 1&gt;NUL
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14.30\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>

--- a/ZPatcher.sln
+++ b/ZPatcher.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33712.159
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LzmaLib", "libs\LzmaLib\LzmaLib.vcxproj", "{C72F7F04-8109-485F-88D4-CB5653CB7DDD}"
 EndProject
@@ -24,7 +24,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ZPatcherLib", "ZPatcherLib\
 		{C72F7F04-8109-485F-88D4-CB5653CB7DDD} = {C72F7F04-8109-485F-88D4-CB5653CB7DDD}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcurl", "libs\curl\projects\Windows\VC14\lib\libcurl.vcxproj", "{DA6F56B4-06A4-441D-AD70-AC5A7D51FADB}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcurl", "libs\curl\projects\Windows\VC14.30\lib\libcurl.vcxproj", "{DA6F56B4-06A4-441D-AD70-AC5A7D51FADB}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ZUpdater", "ZUpdater\ZUpdater.vcxproj", "{2F868D36-FD16-4C3A-B444-8C2CCA1A6A0D}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/ZPatcherLib/ApplyPatch.h
+++ b/ZPatcherLib/ApplyPatch.h
@@ -13,7 +13,6 @@
 #ifndef _APPLYPATCH_H_
 #define _APPLYPATCH_H_
 
-#include <cstring>
 #include <vector>
 
 namespace ZPatcher
@@ -24,23 +23,12 @@ namespace ZPatcher
 	/**
 	* Print the progress bar used applying a patch
 	*/
-	void PrintPatchApplyingProgressBar(const float& Percentage);
-
-	/**
-	* Apply the patch file to the target path
-	*/
-	bool DoApplyPatchFile(FILE* patchFile, const std::string& targetPath, uint64_t& previousVersionNumber, ProgressCallback progressCallback = &PrintPatchApplyingProgressBar);
+	void PrintPatchApplyingProgressBar(const float& percentage);
 
 	/**
 	* Apply the patch file to the target path, given the patch name
 	*/
-	bool ApplyPatchFile(const std::string& patchFileName, const std::string& targetPath, uint64_t& previousVersionNumber, ProgressCallback progressCallback = &PrintPatchApplyingProgressBar);
-
-	/**
-	* Restore the target backup list
-	*/
-	bool RestoreBackup(std::vector<std::string>& backupFileList, std::vector<std::string>& addedFileList, const std::string& baseDirectory, std::string previousVersionNumber);
-
+	bool ApplyPatchFile(const std::string& patchFileName, const std::string& targetPath, const uint64_t& previousVersionNumber, ProgressCallback progressCallback = &PrintPatchApplyingProgressBar);
 }
 
 

--- a/ZPatcherLib/CreatePatch.cpp
+++ b/ZPatcherLib/CreatePatch.cpp
@@ -12,14 +12,15 @@
 
 
 #include "stdafx.h"
-#include "CreatePatch.h"
-#include "FileUtils.h"
-#include "Lzma2Encoder.h"
 #include <algorithm>
 #include <cassert>
 #include <cerrno>
 #include <cinttypes>
+#include "CreatePatch.h"
+#include "FileUtils.h"
+#include "Lzma2Encoder.h"
 #include "LogSystem.h"
+#include "ZPatcherCurrentVersion.h"
 
 
 /**
@@ -251,11 +252,11 @@ static bool DoCreatePatchFile(FILE* patchFile, const std::string& newVersionPath
 
 bool ZPatcher::CreatePatchFile(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList)
 {
-	return CreatePatchFileEx(patchFileName, newVersionPath, patchFileList, &PrintCreatePatchProgressBar, { reinterpret_cast<CompressProgressCallback>(&OnProgress) });
+	return CreatePatchFileEx(patchFileName, newVersionPath, patchFileList, &PrintCreatePatchProgressBar, reinterpret_cast<LZMA_ICompressProgress>(&OnProgress));
 }
 
 
-bool ZPatcher::CreatePatchFileEx(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction, ICompressProgress LZMAProgressCallback)
+bool ZPatcher::CreatePatchFileEx(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction, LZMA_ICompressProgress LZMAProgressCallback)
 {
 	FILE* patchFile;
 
@@ -270,7 +271,7 @@ bool ZPatcher::CreatePatchFileEx(const std::string& patchFileName, const std::st
 		return false;
 	}
 
-	const bool result = DoCreatePatchFile(patchFile, newVersionPath, patchFileList, progressFunction, LZMAProgressCallback);
+	const bool result = DoCreatePatchFile(patchFile, newVersionPath, patchFileList, progressFunction, { reinterpret_cast<CompressProgressCallback>(LZMAProgressCallback) });
 
 	fclose(patchFile);
 

--- a/ZPatcherLib/CreatePatch.cpp
+++ b/ZPatcherLib/CreatePatch.cpp
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 // ZPatcher - Patcher system - Part of the ZUpdater suite
-// Felipe "Zoc" Silveira - (c) 2016-2018
+// Felipe "Zoc" Silveira - (c) 2016-2023
 //
 //////////////////////////////////////////////////////////////////////////
 //
@@ -78,8 +78,8 @@ ZPatcher::PatchFileList_t* ZPatcher::GetDifferencesEx(const std::string& oldVers
 	std::sort(oldVersionFileList.begin(), oldVersionFileList.end());
 	std::sort(newVersionFileList.begin(), newVersionFileList.end());
 
-	unsigned int oldFileIndex = 0;
-	unsigned int newFileIndex = 0;
+	uint64_t oldFileIndex = 0;
+	uint64_t newFileIndex = 0;
 
 	fprintf(stdout, "Detecting file differences between folders...\n");
 
@@ -185,9 +185,9 @@ static bool DoCreatePatchFile(FILE* patchFile, const std::string& newVersionPath
 		float progress = ((float)++i / (float)totalFiles) * 100.0f;
 		progressFunction(progress, i, totalFiles);
 
-		Log(LOG, "[del] %s", *ritr);
+		Log(LOG, "[del] %s", ritr->c_str());
 
-		WriteFileInfo(patchFile, Patch_File_Delete, *ritr);
+		WriteFileInfo(patchFile, Patch_File_Delete, ritr->c_str());
 	}
 
 	for (std::vector<std::string>::iterator itr = patchFileList->AddedFileList.begin(); itr < patchFileList->AddedFileList.end(); ++itr)
@@ -222,9 +222,9 @@ static bool DoCreatePatchFile(FILE* patchFile, const std::string& newVersionPath
 		float progress = ((float)++i / (float)totalFiles) * 100.0f;
 		progressFunction(progress, i, totalFiles);
 
-		Log(LOG, "[mod] %s", *itr);
+		Log(LOG, "[mod] %s", itr->c_str());
 
-		WriteFileInfo(patchFile, Patch_File_Replace, *itr);
+		WriteFileInfo(patchFile, Patch_File_Replace, itr->c_str());
 		std::string localPath = normalizedNewVersionPath + "/" + *itr;
 
 		if (!WriteCompressedFile(hLzma2Enc, localPath, patchFile, LZMAProgressCallback))

--- a/ZPatcherLib/CreatePatch.h
+++ b/ZPatcherLib/CreatePatch.h
@@ -13,13 +13,16 @@
 #ifndef _CREATEPATCH_H_
 #define _CREATEPATCH_H_
 
+#include <string>
 #include <vector>
-#include "LzmaInterfaces.h"
 
 namespace ZPatcher
 {
 	/// Our function pointer callback for progress display
 	typedef void(*ProgressCallback)(const float& percentage, const uint64_t& processedAmount, const uint64_t& totalToBeProcessed);
+
+	/// This is the same as `CompressProgressCallback`, defined in LzmaInterfaces.h, but without the LZMA sdk dependence - using a void* in place of ICompressProgress*
+	typedef int(*LZMA_ICompressProgress)(const void* p, uint64_t inSize, uint64_t outSize);
 
 	/**
 	* This structure holds the files that were Removed, Modified or Added in the patch to be created.
@@ -60,7 +63,7 @@ namespace ZPatcher
 	 * progressFunction is a pointer to a function to display the current progress of file processing.
 	 * LZMAProgressCallback is a pointer to a function to display the current progress of the file being compressed by the LZMA algorithm.
 	 */
-	bool CreatePatchFileEx(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction, ICompressProgress LZMAProgressCallback);
+	bool CreatePatchFileEx(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction, LZMA_ICompressProgress LZMAProgressCallback);
 }
 
 #endif // _CREATEPATCH_H_

--- a/ZPatcherLib/CreatePatch.h
+++ b/ZPatcherLib/CreatePatch.h
@@ -25,38 +25,42 @@ namespace ZPatcher
 	* This structure holds the files that were Removed, Modified or Added in the patch to be created.
 	* Note: This is purposely declared as a class to simplify calling the constructor of each vector ;)
 	*/
-	class PatchFileList_t
+	struct PatchFileList_t
 	{
-	public:
 		std::vector<std::string> RemovedFileList;
 		std::vector<std::string> ModifiedFileList;
 		std::vector<std::string> AddedFileList;
 	};
 
 	/**
-	* Print the progress bar used when comparing directories
+	* Get the difference between two directories (oldVersion and newVersion) and build a PatchFileList_t containing all the changes
 	*/
-	void PrintCreatePatchProgressBar(const float& Percentage, const uint64_t& leftAmount, const uint64_t& rightAmount);
+	PatchFileList_t* GetDifferences(const std::string& oldVersion, const std::string& newVersion);
 
 	/**
 	* Get the difference between two directories (oldVersion and newVersion) and build a PatchFileList_t containing all the changes
+	* This version allows the customization of the Progress Callback
 	*/
-	PatchFileList_t* GetDifferences(std::string& oldVersion, std::string& newVersion, ProgressCallback progressFunction = &PrintCreatePatchProgressBar);
+	PatchFileList_t* GetDifferencesEx(const std::string& oldVersion, const std::string& newVersion, ProgressCallback progressFunction);
 
 	/**
 	 * Creates the patch file with all the changes listed in patchFileList.
-	 * patchfile is the file handle for the target patch file (output file)
+	 * patchFileName is the name of the output file
 	 * newVersionPath is the directory that contains the updated files
 	 * patchFileList is a PatchFileList_t filled by GetDifferences() with the changes between directories
-	 * progressFunction is a pointer to a function to display the current progress. It defaults to our own PrintCreatePatchProgressBar(), but it can be changed.
-	 * LZMAProgressCallback is a pointer to a function to display the current progress of the file being compressed by the LZMA algorithm. It defaults to ZPatcher::OnProgress()
+	 * This function will default to use PrintCreatePatchProgressBar() and OnProgress() (from LZMAInterfaces.h). To change those, use CreatePatchFileEx().
 	 */
-	bool DoCreatePatchFile(FILE* patchFile, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction = &PrintCreatePatchProgressBar, ICompressProgress LZMAProgressCallback = { reinterpret_cast<CompressProgressCallback>(&OnProgress) });
+	bool CreatePatchFile(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList);
 
 	/**
-	 * This is a shortcut to CreatePatchFile() that receives the output patch file as a string
+	 * Creates the patch file with all the changes listed in patchFileList.
+	 * patchFileName is the name of the output file
+	 * newVersionPath is the directory that contains the updated files
+	 * patchFileList is a PatchFileList_t filled by GetDifferences() with the changes between directories
+	 * progressFunction is a pointer to a function to display the current progress of file processing.
+	 * LZMAProgressCallback is a pointer to a function to display the current progress of the file being compressed by the LZMA algorithm.
 	 */
-	bool CreatePatchFile(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction = &PrintCreatePatchProgressBar, ICompressProgress LZMAProgressCallback = { reinterpret_cast<CompressProgressCallback>(&OnProgress) });
+	bool CreatePatchFileEx(const std::string& patchFileName, const std::string& newVersionPath, PatchFileList_t* patchFileList, ProgressCallback progressFunction, ICompressProgress LZMAProgressCallback);
 }
 
 #endif // _CREATEPATCH_H_

--- a/ZPatcherLib/FileUtils.h
+++ b/ZPatcherLib/FileUtils.h
@@ -16,7 +16,6 @@
 
 #include <vector>
 #include <string>
-#include <cstring>
 
 namespace ZPatcher
 {

--- a/ZPatcherLib/LogSystem.h
+++ b/ZPatcherLib/LogSystem.h
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 // ZPatcher - Patcher system - Part of the ZUpdater suite
-// Felipe "Zoc" Silveira - (c) 2016-2018
+// Felipe "Zoc" Silveira - (c) 2016-2022
 //
 //////////////////////////////////////////////////////////////////////////
 //
@@ -13,18 +13,10 @@
 #ifndef _LOGSYSTEM_H_
 #define _LOGSYSTEM_H_
 
-#include <cstdio>
 #include <string>
-#include <map>
 
 namespace ZPatcher
 {
-	// Map that holds all the open log files.
-	extern std::map<std::string, FILE*> g_NewLogSystem;
-
-	// This specifies the directory that will receive the log files
-	extern std::string g_LogDirectory;
-
 	enum LogLevel
 	{
 		LOG,
@@ -33,25 +25,14 @@ namespace ZPatcher
 		LOG_FATAL,
 	};
 
-	// This will create the directory structure defined in 
-	// This function will create a Log/ directory and place files in there.
-	//No logging will be done if this isn't called.
-	bool InitNewLogFile(const std::string& logName);
-
+	// Set the current Active log file to be used by all Log() calls.
 	bool SetActiveLog(const std::string& logName);
 
-	// Build a human-readable timestamp in the format yyyy-mm-dd-hh-mm-ss
-	std::string BuildHumanTimeStamp();
-
-	// Add a line to the target log file. The format should be the same as the one used in printf
-	void Log(std::string logName, LogLevel level, const char* format, ...);
-
-	// Add a line to the ACTIVE log file. Use SetActiveLog() to set the active log file.
+	// Add a line to the Active log file - Use SetActiveLog() to set the active log file. Format is the same as printf()
 	void Log(LogLevel level, const char* format, ...);
 
-	// Close the log file
-	void DestroyLogSystem();
+	// Add a line to the Target log file. Format is the same as printf()
+ 	void LogEx(std::string logName, LogLevel level, const char* format, ...);
 }
 
 #endif //_LOGSYSTEM_H_
-#pragma once

--- a/ZPatcherLib/Lzma2Decoder.cpp
+++ b/ZPatcherLib/Lzma2Decoder.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cassert>
 #include <cerrno>
+#include "Alloc.h"
 #include "Lzma2Dec.h"
 #include "Lzma2Decoder.h"
 #include "LzmaInterfaces.h"
@@ -32,7 +33,7 @@ CLzma2Dec* ZPatcher::InitLzma2Decoder(const Byte& props)
 	CLzma2Dec* dec = static_cast<CLzma2Dec*>(malloc(sizeof(CLzma2Dec)));
 	Lzma2Dec_Construct(dec);
 
-	SRes res = Lzma2Dec_Allocate(dec, props, &LzmaSzAlloc);
+	SRes res = Lzma2Dec_Allocate(dec, props, &g_Alloc);
 	assert(res == SZ_OK);
 
 	return dec;
@@ -40,7 +41,7 @@ CLzma2Dec* ZPatcher::InitLzma2Decoder(const Byte& props)
 
 void ZPatcher::DestroyLzma2Decoder(CLzma2Dec* decoder)
 {
-	Lzma2Dec_Free(decoder, &LzmaSzAlloc);
+	Lzma2Dec_Free(decoder, &g_Alloc);
 }
 
 Byte ZPatcher::ReadPatchFileHeader(FILE* source, Byte& Lzma2Properties)

--- a/ZPatcherLib/Lzma2Decoder.h
+++ b/ZPatcherLib/Lzma2Decoder.h
@@ -14,11 +14,10 @@
 #ifndef _LZMA2DECODER_H_
 #define _LZMA2DECODER_H_
 
-#include "ZPatcherCurrentVersion.h"
-#include "Lzma2Dec.h"
 #include <cstdio>
 #include <string>
-#include <cstring>
+#include "ZPatcherCurrentVersion.h"
+#include "Lzma2Dec.h"
 
 namespace ZPatcher
 {
@@ -42,8 +41,6 @@ namespace ZPatcher
 
 	// Decompress the file data stored in the patch file (only call this in the correct operations!). This operation creates the target file. NOTE: version field is a hack to allow easy migration from patch version 1 to 2. TODO: Rewrite this in a flexible way.
 	bool FileDecompress(CLzma2Dec* decoder, FILE* sourceFile, const std::string& destFileName, const Byte& version = ZPatcher_Version);
-
-
 }
 
 #endif // _LZMA2DECODER_H_

--- a/ZPatcherLib/Lzma2Encoder.cpp
+++ b/ZPatcherLib/Lzma2Encoder.cpp
@@ -11,13 +11,15 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
+#include <cstdint>
+#include <cerrno>
+#include <cassert>
+#include "Alloc.h"
 #include "Lzma2Enc.h"
 #include "Lzma2Encoder.h"
 #include "LzmaInterfaces.h"
 #include "LogSystem.h"
-#include <cstdint>
-#include <cerrno>
-#include <cassert>
+
 
 #ifdef _WIN32
 	#define ftell64 _ftelli64
@@ -29,7 +31,7 @@
 
 CLzma2EncHandle ZPatcher::InitLzma2Encoder()
 {
-	CLzma2EncHandle enc = Lzma2Enc_Create(&LzmaSzAlloc, &LzmaSzAlloc);
+	CLzma2EncHandle enc = Lzma2Enc_Create(&g_Alloc, &g_BigAlloc);
 	assert(enc);
 
 	CLzma2EncProps props;

--- a/ZPatcherLib/Lzma2Encoder.cpp
+++ b/ZPatcherLib/Lzma2Encoder.cpp
@@ -19,6 +19,7 @@
 #include "Lzma2Encoder.h"
 #include "LzmaInterfaces.h"
 #include "LogSystem.h"
+#include "ZPatcherCurrentVersion.h"
 
 
 #ifdef _WIN32

--- a/ZPatcherLib/Lzma2Encoder.h
+++ b/ZPatcherLib/Lzma2Encoder.h
@@ -14,11 +14,9 @@
 #ifndef _LZMA2ENCODER_H_
 #define _LZMA2ENCODER_H_
 
-#include "ZPatcherCurrentVersion.h"
+#include <cstdio>
 #include "Lzma2Enc.h"
 #include "LzmaInterfaces.h"
-#include <cstdio>
-#include <cstring>
 
 namespace ZPatcher
 {

--- a/ZPatcherLib/LzmaInterfaces.cpp
+++ b/ZPatcherLib/LzmaInterfaces.cpp
@@ -61,6 +61,7 @@ SRes ZPatcher::OnProgress(ICompressProgress* p, UInt64 inSize, UInt64 outSize)
 
 void ZPatcher::PrintProgressBar(const float Percentage, UInt64 CurrentFileSize)
 {
+	(void)CurrentFileSize; // Suppress warning about unused parameter
 	const int progressMaxSize = 10;
 
 	int num = fprintf(stdout, " %0.2f %%", Percentage);

--- a/ZPatcherLib/LzmaInterfaces.h
+++ b/ZPatcherLib/LzmaInterfaces.h
@@ -15,14 +15,8 @@
 #define _LZMAALLOCATORS_H_
 
 #include <cstdint>
-#include <cstdlib>
 #include <cstdio>
 #include <string>
-
-#ifdef _WIN32
-	#include <malloc.h>
-#endif
-
 #include "7zFile.h"
 
 namespace ZPatcher

--- a/ZPatcherLib/LzmaInterfaces.h
+++ b/ZPatcherLib/LzmaInterfaces.h
@@ -28,13 +28,6 @@
 namespace ZPatcher
 {
 	//////////////////////////////////////////////////////////////////////////
-	// Allocators
-
-	static void* LzmaAlloc(ISzAllocPtr p, size_t size) { return malloc(size); }
-	static void LzmaFree(ISzAllocPtr p, void *address) { free(address); }
-	static ISzAlloc LzmaSzAlloc = { &LzmaAlloc, &LzmaFree };
-
-	//////////////////////////////////////////////////////////////////////////
 	// File Read Struct
 
 	typedef struct

--- a/ZPatcherLib/ZPatcherLib.vcxproj
+++ b/ZPatcherLib/ZPatcherLib.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{A6C9C679-5FC1-4238-8FEB-1C3394B1DE69}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ZPatcherLib</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/ZPatcherLib/ZPatcherLib.vcxproj
+++ b/ZPatcherLib/ZPatcherLib.vcxproj
@@ -88,7 +88,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
@@ -106,7 +106,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
@@ -123,7 +123,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
@@ -144,7 +144,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/ZUpdater/Main.cpp
+++ b/ZUpdater/Main.cpp
@@ -58,14 +58,12 @@ int main()
 	if (!SelfUpdate(shouldRestart))
 	{
 		WINDOWS_PAUSE();
-		ZPatcher::DestroyLogSystem();
 		exit(EXIT_FAILURE);
 	}
 	else
 	{
 		if (shouldRestart)
 		{
-			ZPatcher::DestroyLogSystem();
 			exit(EXIT_SUCCESS);
 		}
 	}
@@ -83,7 +81,6 @@ int main()
 	{
 		fprintf(stderr, "An error occurred while getting current application version.\n");
 		WINDOWS_PAUSE();
-		ZPatcher::DestroyLogSystem();
 		exit(EXIT_FAILURE);
 	}
 
@@ -94,7 +91,6 @@ int main()
 	{
 		fprintf(stderr, "An error occurred while checking for updates.\n");
 		WINDOWS_PAUSE();
-		ZPatcher::DestroyLogSystem();
 		exit(EXIT_FAILURE);
 	}
 
@@ -104,12 +100,10 @@ int main()
 	if (!DownloadAndApplyPatch(targetDirectory, versionFile, currentVersion))
 	{
 		WINDOWS_PAUSE();
-		ZPatcher::DestroyLogSystem();
 		exit(EXIT_FAILURE);
 	}
 
 	fprintf(stdout, "\n");
 	WINDOWS_PAUSE();
-	ZPatcher::DestroyLogSystem();
 	exit(EXIT_SUCCESS);
 }

--- a/ZUpdater/ZUpdater.cpp
+++ b/ZUpdater/ZUpdater.cpp
@@ -403,17 +403,14 @@ namespace ZUpdater
 			{
 				if (!SaveTargetNewVersion(versionFile, patch.targetBuildNumber))
 				{
-					ZPatcher::DestroyLogSystem();
 					system("pause");
 					return false;
 				}
 
 				currentVersion = patch.targetBuildNumber;
-				ZPatcher::DestroyLogSystem();
 			}
 			else
 			{
-				ZPatcher::DestroyLogSystem();
 				system("pause");
 				return false;
 			}

--- a/ZUpdater/ZUpdater.vcxproj
+++ b/ZUpdater/ZUpdater.vcxproj
@@ -22,32 +22,32 @@
     <ProjectGuid>{2F868D36-FD16-4C3A-B444-8C2CCA1A6A0D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ZUpdater</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -103,7 +103,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_lib;$(SolutionDir)\libs\curl\build\Win32\VC14\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_lib;$(SolutionDir)\libs\curl\build\Win32\VC14.30\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurld.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -121,7 +121,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14.30\LIB Debug - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurld.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -142,7 +142,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_lib;$(SolutionDir)\libs\curl\build\Win32\VC14\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_lib;$(SolutionDir)\libs\curl\build\Win32\VC14.30\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurl.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -163,7 +163,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\LzmaLib\;$(SolutionDir)\_Output\$(PlatformTarget)\$(Configuration)\ZPatcherLib\;$(SolutionDir)\bin\$(Platform)-$(Configuration)-Lib\;$(SolutionDir)\libs\wxWidgets\lib\vc_x64_dll;$(SolutionDir)\libs\curl\build\Win64\VC14.30\LIB Release - DLL Windows SSPI;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>LzmaLib.lib;ZPatcherLib.lib;ws2_32.lib;wininet.lib;wldap32.lib;comctl32.lib;crypt32.lib;libcurl.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 3.0.{build}
 
-image: Visual Studio 2015
+image: Visual Studio 2022
 
 configuration:
   - Debug
@@ -14,31 +14,7 @@ install:
   - ps: >-
       git submodule update -q --init --recursive
 
-      .\libs\curl\projects\generate.bat vc14
-
-      Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxWidgets-3.1.6-headers.7z" -outfile "wxWidgets-3.1.6-headers.7z"
-
-      Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxMSW-3.1.6_vc14x_x64_Dev.7z" -outfile "wxMSW-3.1.6_vc14x_x64_Dev.7z"
-
-      Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxMSW-3.1.6_vc14x_x64_ReleaseDLL.7z" -outfile "wxMSW-3.1.6_vc14x_x64_ReleaseDLL.7z"
-
-      Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxMSW-3.1.6_vc14x_Dev.7z" -outfile "wxMSW-3.1.6_vc14x_Dev.7z"
-
-      Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxMSW-3.1.6_vc14x_ReleaseDLL.7z" -outfile "wxMSW-3.1.6_vc14x_ReleaseDLL.7z"
-
-      7z.exe x -y ".\wxWidgets-3.1.6-headers.7z" -o".\libs\wxWidgets"
-
-      7z.exe x -y ".\wxMSW-3.1.6_vc14x_x64_Dev.7z" -o".\libs\wxWidgets"
-
-      7z.exe x -y ".\wxMSW-3.1.6_vc14x_x64_ReleaseDLL.7z" -o".\libs\wxWidgets"
-
-      7z.exe x -y ".\wxMSW-3.1.6_vc14x_Dev.7z" -o".\libs\wxWidgets"
-
-      7z.exe x -y ".\wxMSW-3.1.6_vc14x_ReleaseDLL.7z" -o".\libs\wxWidgets"
-
-      move ".\libs\wxWidgets\lib\vc14x_x64_dll\" ".\libs\wxWidgets\lib\vc_x64_dll\"
-
-      move ".\libs\wxWidgets\lib\vc14x_dll\" ".\libs\wxWidgets\lib\vc_dll\"
+      .\setup-external-dependencies.ps1
 build:
     project: .\ZPatcher.sln
     verbosity: minimal

--- a/libs/LzmaLib/LzmaLib.vcxproj
+++ b/libs/LzmaLib/LzmaLib.vcxproj
@@ -22,30 +22,30 @@
     <SccProjectName />
     <SccLocalPath />
     <ProjectGuid>{C72F7F04-8109-485F-88D4-CB5653CB7DDD}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/setup-external-dependencies.ps1
+++ b/setup-external-dependencies.ps1
@@ -1,6 +1,6 @@
 git submodule update -q --init --recursive
 
-.\libs\curl\projects\generate.bat vc14
+.\libs\curl\projects\generate.bat "vc14.30"
 
 Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxWidgets-3.1.6-headers.7z" -outfile "wxWidgets-3.1.6-headers.7z"
 Invoke-WebRequest "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxMSW-3.1.6_vc14x_x64_Dev.7z" -outfile "wxMSW-3.1.6_vc14x_x64_Dev.7z"


### PR DESCRIPTION
- [ ] Build a separate slim library that supports only patch application

Smaller tasks that went in:
- [x] Removed custom allocators. We now use the ones supplied by `Alloc.h`, which includes the Big allocator. This should allow a faster operation when allocating for larger files and the OS provides (e.g. VirtualAlloc on Windows)
- [x] Simplified and cleaned up the log system
- [x] Simplified and cleared up the CreatePatch() and ApplyPatch() function calls. There are now Ex function variants to allow for more customization
- [x] CreatePatch() now normalizes the patches passed to it internally
- [x] Removed a few auxiliary functions from the header files - they are now static to the cpp file